### PR TITLE
Included datascienceblog.net

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ A curated list of data science blogs
 * Datanice https://datanice.wordpress.com/ [(RSS)](https://datanice.wordpress.com/feed/)
 * Dataquest Blog https://www.dataquest.io/blog/ [(RSS)](https://www.dataquest.io/blog/atom.xml)
 * DataRobot http://www.datarobot.com/blog/ [(RSS)](http://www.datarobot.com/feed/)
+* Datascienceblog.net https://www.datascienceblog.net [(RSS)](https://www.datascienceblog.net/post/index.xml)
 * Datascope http://datascopeanalytics.com/blog [(RSS)](http://datascopeanalytics.com/rss)
 * DatasFrame http://tomaugspurger.github.io/ [(RSS)](http://tomaugspurger.github.io/feeds/all.rss.xml)
 * David Mimno http://www.mimno.org/ [(RSS)](http://mimno.infosci.cornell.edu/b/feed.xml)


### PR DESCRIPTION
I've added my datascienceblog at www.datascienceblog.net to the list of blogs. The blog mostly deals with statistical testing, data visualization, and machine learning. Thank you for merging :-)